### PR TITLE
Tweak board name/result margin

### DIFF
--- a/src/styl/board-content.styl
+++ b/src/styl/board-content.styl
@@ -96,9 +96,9 @@
       white-space nowrap
       overflow hidden
       text-overflow ellipsis
+      margin-left 5px
     > .result
       padding 0 5px
-      margin-right 5px
       border-right 1px solid borderColor
   > .player_bar_clock
     flex 0 0 auto


### PR DESCRIPTION
Closes #1992. Note that the halfsize name margin is affected on **incomplete** games in both **half and full sizes.**

| Branch | Completion status | Size | Screenshot | 
| ------- | ---- | --- | --- |
| master | incomplete | 1️⃣   | https://user-images.githubusercontent.com/569991/150544244-1959c39f-006f-4726-861e-a7f6c51446c5.png |
| master | incomplete | ½ | https://user-images.githubusercontent.com/569991/150544339-1331f656-2120-4923-b5d2-0f1d57709eab.png |
| master | complete | 1️⃣  | https://user-images.githubusercontent.com/569991/150544586-a219753c-3220-4f82-ae32-acb816a32d57.png |
| master | complete | ½  | https://user-images.githubusercontent.com/569991/150544631-25ade26c-0da6-4b26-ab85-c44db0c505d8.png |
| this | incomplete | 1️⃣  | **name left margin affected** https://user-images.githubusercontent.com/569991/150544944-27efe402-9df6-4503-b3a4-0da866790e4e.png |
| this | incomplete | ½  | **name left margin affected** https://user-images.githubusercontent.com/569991/150545051-2e1bbfed-845f-401b-b061-0e4d1fa42810.png |
| this | complete | 1️⃣  | **same as before** https://user-images.githubusercontent.com/569991/150544986-1bdc74d8-ce70-4e19-b92f-711573f9592b.png |
| this | complete | ½  | **same as before** https://user-images.githubusercontent.com/569991/150545020-dae073f7-b374-4e2a-8f81-611d8060b7cd.png |
 