### PR TITLE
Stop clocks until move readback is received

### DIFF
--- a/src/ui/shared/round/OnlineRound.ts
+++ b/src/ui/shared/round/OnlineRound.ts
@@ -702,6 +702,12 @@ export default class OnlineRound implements OnlineRoundInterface {
       blur
     }
 
+    // Pauses both clocks. When the server echoes back this move, the clocks will resume.
+    // This prevents a confusing user experience where a laggy network makes it appear that
+    // it's still the user's turn; see #2000.
+    this.clock?.stopClock()
+    redraw()
+
     if (isMoveRequest(moveOrDropReq)) {
       this.socket.iface.send('move', moveOrDropReq, opts)
     }

--- a/src/ui/shared/round/clock/clockView.ts
+++ b/src/ui/shared/round/clock/clockView.ts
@@ -5,7 +5,6 @@ import ClockCtrl from './ClockCtrl'
 export interface ClockAttrs {
   ctrl: ClockCtrl
   color: Color
-  runningColor?: Color
   isBerserk: boolean
 }
 
@@ -28,9 +27,9 @@ export default {
   },
 
   view({ attrs }) {
-    const { ctrl, color, runningColor, isBerserk } = attrs
+    const { ctrl, color, isBerserk } = attrs
     const time = ctrl.millisOf(color)
-    const isRunning = runningColor === color
+    const isRunning = color === ctrl.times.activeColor
     const className = helper.classSet({
       clock: true,
       outoftime: !time,

--- a/src/ui/shared/round/view/roundView.tsx
+++ b/src/ui/shared/round/view/roundView.tsx
@@ -315,8 +315,6 @@ function renderAntagonistInfo(ctrl: OnlineRound, player: Player, material: Mater
 
   const checksNb = getChecksCount(ctrl, player.color)
 
-  const runningColor = ctrl.isClockRunning() ? ctrl.data.game.player : undefined
-
   const tournamentRank = ctrl.data.tournament && ctrl.data.tournament.ranks ?
     '#' + ctrl.data.tournament.ranks[player.color] + ' ' : null
 
@@ -359,7 +357,6 @@ function renderAntagonistInfo(ctrl: OnlineRound, player: Player, material: Mater
           ctrl: ctrl.clock,
           color: player.color,
           isBerserk,
-          runningColor
         }) :
         isCrazy && ctrl.correspondenceClock ?
           renderCorrespondenceClock(
@@ -376,7 +373,6 @@ function renderPlayTable(
   material: Material,
   position: Position,
 ) {
-  const runningColor = ctrl.isClockRunning() ? ctrl.data.game.player : undefined
   const step = ctrl.plyStep(ctrl.vm.ply)
   const isCrazy = !!step.crazy
 
@@ -403,7 +399,6 @@ function renderPlayTable(
           ctrl: ctrl.clock,
           color: player.color,
           isBerserk: ctrl.vm.goneBerserk[player.color],
-          runningColor
         }) :
         !isCrazy && ctrl.correspondenceClock ?
           renderCorrespondenceClock(


### PR DESCRIPTION
Addresses #2000 and probably some other reports.

Currently, the app shows the current player's clock as active until it receives the move "readback" from the server. On high-latency connections, this can be confusing, as it may appear that the app hasn't registered or sent the move.

The solution implemented on the desktop site in https://github.com/lichess-org/lila/commit/0061c263b87953c1d8ec1368ed25cf837b7d6a33 / https://github.com/lichess-org/lila/pull/3300 was to stop the clocks when sending a move, which is what this PR mirrors.

Tested locally with network conditioning - will attach a screen cap shortly.

See:
- [lila round control `actualSendMove`](https://github.com/lichess-org/lila/blob/cd6e215c691141c76dcd3ee946b39a60ebca02d4/ui/round/src/ctrl.ts#L326)
- [lila clock view](https://github.com/lichess-org/lila/blob/bce9fd8f0ebe8d9766bad1ebb00051185cc33ac0/ui/round/src/clock/clockView.ts#L14)