### PR TITLE
Refine JSX typing

### DIFF
--- a/src/dts/jsx.d.ts
+++ b/src/dts/jsx.d.ts
@@ -4,7 +4,5 @@ declare namespace JSX {
     [type: string]: Element
   }
 
-  interface ElementClass {
-    view: any
-  }
+  type ElementClass = Mithril.ClassComponent
 }

--- a/src/dts/jsx.d.ts
+++ b/src/dts/jsx.d.ts
@@ -1,5 +1,5 @@
 declare namespace JSX {
-  type Element = any
+  type Element = Mithril.Vnode
   interface IntrinsicElements {
     [type: string]: Mithril.Attributes
   }

--- a/src/dts/jsx.d.ts
+++ b/src/dts/jsx.d.ts
@@ -1,7 +1,7 @@
 declare namespace JSX {
   type Element = any
   interface IntrinsicElements {
-    [type: string]: Element
+    [type: string]: Mithril.Attributes
   }
 
   type ElementClass = Mithril.ClassComponent

--- a/src/ui/shared/BoardBrush/svg.tsx
+++ b/src/ui/shared/BoardBrush/svg.tsx
@@ -77,16 +77,13 @@ export function piece(theme: string, pos: BoardPos, piece: Piece, bounds: Client
   let name = piece.color === 'white' ? 'w' : 'b'
   name += (piece.role === 'knight' ? 'n' : piece.role[0]).toUpperCase()
   const href = `images/pieces/${theme}/${name}.svg`
-  return {
-    tag: 'image',
-    attrs: {
-      x: o[0] - size / 2,
-      y: o[1] - size / 2,
-      width: size,
-      height: size,
-      'xlink:href': href,
-    }
-  }
+  return h('image', {
+    x: o[0] - size / 2,
+    y: o[1] - size / 2,
+    width: size,
+    height: size,
+    'xlink:href': href,
+  })
 }
 
 export function annotation(pos: BoardPos, glyph: Glyph, bounds: ClientRect) {

--- a/src/ui/shared/round/view/button.tsx
+++ b/src/ui/shared/round/view/button.tsx
@@ -179,7 +179,7 @@ export default {
     ])
     return null
   },
-  answerOpponentTakebackProposition(ctrl: OnlineRound): Mithril.Child {
+  answerOpponentTakebackProposition(ctrl: OnlineRound) {
     if (ctrl.data.opponent.proposingTakeback) return h('div.negotiation', [
       h('div.notice', i18n('yourOpponentProposesATakeback')),
       h('div.binary_choice_wrapper', [


### PR DESCRIPTION
I know JSX is legacy code in this repo, but it's still adding a lot of lint noise because the type checker sees JSX elements as `any` instead of `Mithril.Vnode`. These small changes resulted in an almost 10% reduction in lint warnings.

### Before
```
$ npm run lint
...
2275 problems (0 errors, 2275 warnings)
```

### After
```
$ npm run lint
...
2059 problems (0 errors, 2059 warnings)
```