### PR TITLE
Retry fixing #1869 (bad display on square screen)

### DIFF
--- a/src/styl/board-content.styl
+++ b/src/styl/board-content.styl
@@ -51,7 +51,7 @@
     width var(--board-side-land-tablet)
     margin auto
     margin-left 3vh
-  @media only screen and (min-aspect-ratio: 716/720) and (max-aspect-ratio: 720/716)
+  @media only screen and (min-aspect-ratio: 665/716) and (max-aspect-ratio: 716/665)
     height 60vw
     width 60vw
     margin auto


### PR DESCRIPTION
Sorry @veloce , I didn't give you the proper data to fix #1869. Although the screen size is reportedly 716x720, it seems that the viewport size is just 665x716 (as reported by Chrome when doing remote debugging)

After applying this change, this is how the screen looks:

![image](https://user-images.githubusercontent.com/1150630/158470132-6a358643-c4d3-41f7-a82e-57a660904e2d.png)

I have no idea about media queries, so I'm not exactly sure why you pinned the aspect-ratio between 716/720 and 720/716, but I have preserved that. Happy to make more tests if needed, now that I figured out how to build/debug.
