### PR TITLE
change router path and set tv channel in settings object

### DIFF
--- a/src/ui/home/homeView.tsx
+++ b/src/ui/home/homeView.tsx
@@ -6,6 +6,7 @@ import { emptyFen } from '../../utils/fen'
 import { gameIcon, hasNetwork } from '../../utils'
 import i18n, { plural, formatNumber, distanceToNowStrict } from '../../i18n'
 import session from '../../session'
+import settings from '../../settings'
 import { PongMessage, CorrespondenceSeek } from '../../lichess/interfaces'
 import spinner from '../../spinner'
 import * as helper from '../helper'
@@ -277,7 +278,8 @@ function renderFeaturedGame(ctrl: HomeCtrl) {
     orientation: featured.orientation,
     lastMove: featured.lastMove,
     link: () => {
-      router.set('/tv?channel=best')
+      settings.tv.channel('best')
+      router.set('/tv')
     },
     gameObj: featured,
   } : {


### PR DESCRIPTION
related to #1740 

I removed path parameter from the from `router` path and updated the `tv.channel` value in the `settings`,
after this Lichess TV is showing right games on selecting game types.