### PR TITLE
Make game events emit haptic effects

### DIFF
--- a/src/ui/shared/round/OnlineRound.ts
+++ b/src/ui/shared/round/OnlineRound.ts
@@ -414,7 +414,7 @@ export default class OnlineRound implements OnlineRoundInterface {
         this.vm.submitFeedback = undefined
         if (playing) {
           sound.confirmation()
-          vibrate.quick()
+          vibrate.tap()
         }
         redraw()
       }, feebackDuration)
@@ -434,15 +434,19 @@ export default class OnlineRound implements OnlineRoundInterface {
       d.game.winner = o.winner
     }
 
+    if (o.check) {
+      vibrate.doubleTap()
+    }
+
     const wDraw = white.offeringDraw
     const bDraw = black.offeringDraw
     if (!wDraw && o.wDraw) {
       sound.dong()
-      vibrate.quick()
+      vibrate.warn()
     }
     if (!bDraw && o.bDraw) {
       sound.dong()
-      vibrate.quick()
+      vibrate.warn()
     }
     white.offeringDraw = o.wDraw
     black.offeringDraw = o.bDraw
@@ -631,7 +635,11 @@ export default class OnlineRound implements OnlineRoundInterface {
 
     if (d.game.turns > 1) {
       sound.dong()
-      vibrate.quick()
+      if (d.player.color === d.game.winner) {
+        vibrate.good()
+      } else {
+        vibrate.bad()
+      }
     }
     if (!this.data.player.spectator) {
       session.backgroundRefresh()
@@ -742,12 +750,14 @@ export default class OnlineRound implements OnlineRoundInterface {
       else {
         sound.capture()
       }
+      if (!this.data.player.spectator) {
+        vibrate.heavy()
+      }
     } else {
       sound.move()
-    }
-
-    if (!this.data.player.spectator) {
-      vibrate.quick()
+      if (!this.data.player.spectator) {
+        vibrate.tap()
+      }
     }
   }
 

--- a/src/vibrate.ts
+++ b/src/vibrate.ts
@@ -1,4 +1,4 @@
-import { Haptics } from '@capacitor/haptics'
+import { Haptics, ImpactStyle, NotificationType } from '@capacitor/haptics'
 import settings from './settings'
 
 let shouldVibrate: boolean = settings.general.vibrateOnGameEvents()
@@ -6,9 +6,70 @@ let shouldVibrate: boolean = settings.general.vibrateOnGameEvents()
 export default {
   quick() {
     if (shouldVibrate) {
-      if (window.navigator.vibrate) window.navigator.vibrate(150)
-      else Haptics.vibrate()
+      if (window.navigator.vibrate) {
+        window.navigator.vibrate(150)
+      } else {
+          void Haptics.vibrate()
+      }
     }
+  },
+  tap() {
+    if (shouldVibrate) {
+      if (window.navigator.vibrate) {
+        window.navigator.vibrate(50)
+      } else {
+        void Haptics.impact({ style: ImpactStyle.Medium })
+      }
+    }    
+  },
+  heavy() {
+    if (shouldVibrate) {
+      if (window.navigator.vibrate) {
+        window.navigator.vibrate(100)
+      } else {
+        void Haptics.impact({ style: ImpactStyle.Heavy })
+      }
+    }    
+  },    
+  doubleTap() {
+    if (shouldVibrate) {
+      if (window.navigator.vibrate) {
+        window.navigator.vibrate(50)
+      } else {        
+        void Haptics.impact({ style: ImpactStyle.Medium }).then(() => {
+          void new Promise(r => setTimeout(r, 150)).then(() => {
+            void Haptics.impact({ style: ImpactStyle.Medium })  
+          })
+        })
+      }
+    }    
+  },
+  warn() {
+    if (shouldVibrate) {
+      if (window.navigator.vibrate) {
+        window.navigator.vibrate(50)
+      } else {
+        void Haptics.notification({ type: NotificationType.Warning })
+      }
+    }    
+  },
+  bad() {
+    if (shouldVibrate) {
+      if (window.navigator.vibrate) {
+        window.navigator.vibrate(50)
+      } else {
+        void Haptics.notification({ type: NotificationType.Error })
+      }
+    }    
+  },
+  good() {
+    if (shouldVibrate) {
+      if (window.navigator.vibrate) {
+          window.navigator.vibrate(50)
+      } else {
+        void Haptics.notification({ type: NotificationType.Success })
+      }
+    }    
   },
   onSettingChange(v: boolean) {
     shouldVibrate = v


### PR DESCRIPTION
Instead of a generic 'vibrate' game events now emit different haptic effects.

There are different effects for:
- Regular move
- Capture
- Check
- Draw
- Win
- Lose

Fixes: #1918

Caveat: 
I have very little idea what I'm doing here. Haven't used capacitor before and it's been quite a while since I touched mobile dev.
Seems to work as expected though, both in "play against computer" and online play.
