### PR TITLE
Implement nice haptics for AI games

### DIFF
--- a/src/ui/ai/AiRound.ts
+++ b/src/ui/ai/AiRound.ts
@@ -286,7 +286,6 @@ export default class AiRound implements AiRoundInterface, PromotingInterface {
     } else {
       sound.move()
     }
-    vibrate.quick()
   }
 
   private onUserNewPiece = (role: Role, key: Key) => {
@@ -313,6 +312,12 @@ export default class AiRound implements AiRoundInterface, PromotingInterface {
         movableColor: sit.player === this.data.player.color ? sit.player : null,
         check: sit.check
       })
+
+      if (sit.check) {
+        vibrate.doubleTap()
+      } else {
+        vibrate.tap()
+      }
     }
   }
 


### PR DESCRIPTION
Addresses https://github.com/lichess-org/lichobile/issues/2090

In https://github.com/lichess-org/lichobile/pull/2079 the nicer haptics are used only on online games. This PR does the same for computer games.

I moved the vibration code from `onMove()` to `apply(sit:)` so we can check wether the last move is a check (and double tap when it's the case).

