### PR TITLE
Scale promo piece size relative to screen width

### DIFF
--- a/src/styl/game.styl
+++ b/src/styl/game.styl
@@ -280,20 +280,23 @@
     background-image url(../../images/pieces/mono/K.svg)
 
 #promotion_choice
+  --overlay-height 100px
   border 1px solid black
   background-color rgba(255,255,255, 0.7)
   position absolute
-  top calc((100vh - 100px) / 2)
-  height 100px
+  top calc((100vh - var(--overlay-height)) / 2)
+  height var(--overlay-height)
   width 100%
-  text-align center
+  display flex
+  justify-content center
+  align-items center
+  column-gap 5px
   piece
     position relative
-    display inline-block
-    width 60px
-    height 60px
-    margin 0 5px
-    top 17px
+    width calc(min(12.5%, var(--overlay-height)))
+    // CSS hack: padding-bottom is calculated based on width of parent, so we can get a square div here
+    height 0
+    padding-bottom calc(min(12.5%, var(--overlay-height)))
 
 .tableHeader
   display flex


### PR DESCRIPTION
Fixes #2074.

### Description

Promo pieces are currently scaled to 60x60px, which gets too big when the base zoom is scaled up or down, as detailed in the linked issue.

To make the promo overlay pieces the same size as the pieces on the board, this PR essentially aims to change the promo piece height and width to 12.5% of the overlay (and screen) width. It will consequently often match the board piece width, and is in any case reasonably legible.

In order to actually match the height to 12.5% of width, I had to write a CSS hack, as indicated by a comment. I also capped the piece width/height at 100% of the overlay height in order to keep the pieces within the overlay bounds in edge-case font/screen configurations.

Lastly, I took the liberty of making the promo overlay a flex component. This might not have been necessary but I found it slightly easier to reason about. Happy to revert that bit if desired.

### New styling with various screen widths

https://user-images.githubusercontent.com/569991/168482522-30680a5e-3fa0-4beb-ae15-cb139cfce527.mov

### New styling with various base zooms

Note that zoom adjustments affect the base px size; since the overlay height and column gap are specified in px, they're subject to change size too.

https://user-images.githubusercontent.com/569991/168482517-1d16de25-5d85-4aad-9219-6cb81bcc2b11.mov