### PR TITLE
android: Monochrome icon for Android 13+

### DIFF
--- a/android/app/src/main/res/drawable/ic_launcher_monochrome.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_monochrome.xml
@@ -1,0 +1,16 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group
+        android:translateX="29"
+        android:translateY="29">
+        <path
+            android:strokeWidth="1"
+            android:pathData="M38.956,0.5c-3.53,0.418 -6.452,0.902 -9.286,2.984C5.534,1.786 -0.692,18.533 0.68,29.364 3.493,50.214 31.918,55.785 41.329,41.7c-7.444,7.696 -19.276,8.752 -28.323,3.084C3.959,39.116 -0.506,27.392 4.683,17.567 9.873,7.742 18.996,4.535 29.03,6.405c2.43,-1.418 5.225,-3.22 7.655,-3.187l-1.694,4.86 12.752,21.37c-0.439,5.654 -5.459,6.112 -5.459,6.112 -0.574,-1.47 -1.634,-2.942 -4.842,-6.036 -3.207,-3.094 -17.465,-10.177 -15.788,-16.207 -2.001,6.967 10.311,14.152 14.04,17.663 3.73,3.51 5.426,6.04 5.795,6.756 0,0 9.392,-2.504 7.838,-8.927L37.4,7.171z"
+            android:strokeLineJoin="round"
+            android:fillColor="#000000"
+            android:strokeColor="#000000" />
+        </group>
+</vector>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
Add a monochrome vector drawable in ic_launcher_round.xml in order to
support Android 13's Themed Icons feature in the launcher.

Preview: 
![image](https://user-images.githubusercontent.com/29994884/172076031-ca08f6b7-1ae1-4934-a7d9-af7b3f6ce896.png)


Signed-off-by: Gegham Zakaryan <zakaryan.2004@outlook.com>