### PR TITLE
Board Editor: Tap to place piece

### DIFF
--- a/src/chessground/Chessground.ts
+++ b/src/chessground/Chessground.ts
@@ -8,6 +8,7 @@ import fen from './fen'
 import { renderBoard, makeCoords, makeSymmCoords } from './render'
 import { anim, skip as skipAnim } from './anim'
 import * as drag from './drag'
+import {placePieceInHand} from "./drag";
 
 const pieceScores: { [id: string]: number } = {
   pawn: 1,
@@ -69,7 +70,11 @@ export default class Chessground {
     if (!isViewOnly) {
       board.addEventListener('touchstart', (e: TouchEvent) => drag.start(this, e))
       board.addEventListener('touchmove', (e: TouchEvent) => drag.move(this, e))
-      board.addEventListener('touchend', (e: TouchEvent) => drag.end(this, e))
+      board.addEventListener('touchend', (e: TouchEvent) => {
+        const { clientX, clientY } = e.changedTouches[0];
+        placePieceInHand(this, [clientX, clientY], bounds);
+        drag.end(this, e)
+      });
       board.addEventListener('touchcancel', () => drag.cancel(this))
     }
 

--- a/src/chessground/board.ts
+++ b/src/chessground/board.ts
@@ -66,8 +66,8 @@ export function apiMove(state: State, orig: Key, dest: Key): boolean {
   return baseMove(state, orig, dest)
 }
 
-export function apiNewPiece(state: State, piece: Piece, key: Key): boolean {
-  return baseNewPiece(state, piece, key)
+export function apiNewPiece(state: State, piece: Piece, key: Key, force = false): boolean {
+  return baseNewPiece(state, piece, key, force)
 }
 
 export function userMove(state: State, orig: Key, dest: Key): boolean {
@@ -134,6 +134,10 @@ export function setSelected(state: State, key: Key | null): void {
 export function unselect(state: State): void {
   state.selected = null
   state.premovable.dests = null
+}
+
+export function setPieceInHand(state: State, piece: Piece | null, force = false): void {
+  state.pieceInHand = piece ? { ...piece, force } : null;
 }
 
 export function isMovable(state: State, orig: Key): boolean {

--- a/src/chessground/drag.ts
+++ b/src/chessground/drag.ts
@@ -5,6 +5,7 @@ import Chessground from './Chessground'
 import * as board from './board'
 import * as util from './util'
 import { anim } from './anim'
+import {apiNewPiece} from "./board";
 
 export interface DragCurrent {
   orig: Key // orig key of dragging piece
@@ -204,6 +205,22 @@ export function cancel(ctrl: Chessground) {
   if (state.draggable.current) {
     state.draggable.current = null
     board.unselect(state)
+  }
+}
+
+export function placePieceInHand(ctrl: Chessground, position: NumberPair, bounds: ClientRect) {
+  const state = ctrl.state;
+
+  if (state.pieceInHand) {
+    const [x, y] = position;
+    const key = getKeyAtDomPos(state, [x, y], bounds);
+
+    if (key) {
+      apiNewPiece(state, state.pieceInHand, key, state.pieceInHand.force);
+    }
+    state.pieceInHand = null;
+
+    ctrl.redraw();
   }
 }
 

--- a/src/chessground/state.ts
+++ b/src/chessground/state.ts
@@ -4,6 +4,7 @@ import { DragCurrent } from './drag'
 
 export interface State {
   pieces: cg.Pieces
+  pieceInHand: Piece & { force: boolean } | null
   orientation: Color // board orientation. white | black
   turnColor: Color // turn to play. white | black
   check: Key | null // square currently in check "a2"
@@ -85,6 +86,7 @@ export interface State {
 export function makeDefaults(): State {
   return {
     pieces: new Map(),
+    pieceInHand: null,
     orientation: 'white' as Color,
     turnColor: 'white' as Color,
     check: null,

--- a/src/ui/editor/EditorCtrl.ts
+++ b/src/ui/editor/EditorCtrl.ts
@@ -18,6 +18,7 @@ import continuePopup, { Controller as ContinuePopupCtrl } from '../shared/contin
 import i18n from '../../i18n'
 import drag from './drag'
 import { EditorState, BoardPosition, BoardPositionCategory, CastlingToggle, CastlingToggles, CASTLING_TOGGLES } from './interfaces'
+import {setPieceInHand} from "~/chessground/board";
 
 export default class EditorCtrl {
   public menu: MenuInterface
@@ -121,8 +122,29 @@ export default class EditorCtrl {
     redraw()
   }
 
-  public onstart = (e: TouchEvent): void => drag(this, e)
+
+  private pickUp = (e: TouchEvent) => {
+    if (e.touches && e.touches.length > 1) return // support one finger touch only
+    const role = (e.target as HTMLElement).getAttribute('data-role'),
+    color = (e.target as HTMLElement).getAttribute('data-color')
+    if (!role || !color) return
+    e.stopPropagation()
+    e.preventDefault()
+
+    const piece = {
+      role: (role as Role),
+      color: (color as Color)
+    }
+
+    setPieceInHand(this.chessground.state, piece, true);
+  }
+
+  public onstart = (e: TouchEvent): void => {
+    this.pickUp(e);
+    drag(this, e)
+  }
   public onmove = (e: TouchEvent): void => cgDrag.move(this.chessground, e)
+
   public onend = (e: TouchEvent): void => cgDrag.end(this.chessground, e)
 
   public editorOnCreate = (vn: Mithril.VnodeDOM): void => {


### PR DESCRIPTION
On the board editor page, you used to only be able to add new pieces by dragging them onto the board. This always bugged me, and I imagine it must be horrible on tablets due to the large screen and large distance to drag. I also thought there was something wrong with the app when I tried to tap and it didn't work.

This adds a `pieceInHand` to `Chessground.state`, which holds both the piece, and whether it should overwrite the piece under it when placed. Clicking a piece in the bottom panel populates this property. Clicking anywhere on the board will place the piece and clear the `pieceInHand` property. 

I'm unsure about the last part, it may be useful to not clear the `pieceInHand`, so the user can place all the pieces of a given type and colour at once. But this would also require a button to clear the field, and potentially some UI work to communicate that there is a piece in hand.

Lastly, my apologies if this is suboptimally implemented, I'm very new to the codebase and I've scarcely convinced it to build on my machine.