### PR TITLE
Domain verification: app portion

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
-            <intent-filter>
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />


### PR DESCRIPTION
This ensures that the Android system automatically checks the declared domain (lichess.org) by looking for the file
/.well-known/assetlinks.json and verifying the package name and signature finger print listed there.

More info:
https://developer.android.com/training/app-links/verify-site-associations

Fixes #1457, with the help of (already deployed [lila#11062](https://github.com/lichess-org/lila/pull/11062))