### PR TITLE
Added current number of move to the chess clock ui #2024

### DIFF
--- a/src/styl/clock.styl
+++ b/src/styl/clock.styl
@@ -55,12 +55,17 @@
   font-size 3em
   opacity 0.7
   > button
-    width 25%
+    width 20%
     text-align center
     margin-right 0
+  > .moveNumber 
+    width 20%
+    text-align center
+    @media only screen and (orientation: portrait)
+      transform:rotate(90deg)
   @media only screen and (orientation: landscape)
     order 1
-
+  
 .clockTime
   font-size 100px
   &.long

--- a/src/ui/clock/ChessClockCtrl.ts
+++ b/src/ui/clock/ChessClockCtrl.ts
@@ -14,6 +14,7 @@ export interface IChessClockCtrl {
   goHome: () => void
   clockTap: (side: 'white' | 'black') => void
   clockType: Prop<ClockType>
+  getMove: () => number
 }
 
 function noop() { /* noop */ }
@@ -22,17 +23,20 @@ export default function ChessClockCtrl(): IChessClockCtrl {
 
   const clockType: Prop<ClockType> = prop(settings.clock.clockType())
   const clockObj: Prop<IChessClock> = prop(clockSet[clockType()](noop))
-
+  let currentMove: number= 1
+  
   function reload() {
     if (clockObj() && clockObj().isRunning() && !clockObj().flagged()) return
     clockType(settings.clock.clockType())
     clockObj(clockSet[clockType()](noop))
+    currentMove = 1
   }
 
   const clockSettingsCtrl = clockSettings.controller(reload, clockObj)
 
   function clockTap(side: 'white' | 'black') {
     clockObj().clockHit(side)
+    currentMove += 0.5
   }
 
   function startStop () {
@@ -45,6 +49,10 @@ export default function ChessClockCtrl(): IChessClockCtrl {
     }
   }
 
+  function getMove() {
+    return Math.floor(currentMove)
+  }
+
   return {
     startStop,
     clockSettingsCtrl,
@@ -53,5 +61,6 @@ export default function ChessClockCtrl(): IChessClockCtrl {
     goHome,
     clockTap,
     clockType,
+    getMove
   }
 }

--- a/src/ui/clock/clockView.tsx
+++ b/src/ui/clock/clockView.tsx
@@ -21,7 +21,6 @@ export function clockBody(ctrl: IChessClockCtrl) {
   const whiteFlagged = clock.flagged() === 'white'
   const blackFlagged = clock.flagged() === 'black'
   const flagged = whiteFlagged || blackFlagged
-
   const whiteClockClass = [
     'clockTapArea',
     'white',
@@ -79,6 +78,7 @@ export function clockBody(ctrl: IChessClockCtrl) {
         <button className={'fa fa-refresh' + ((clock.isRunning() && !flagged) ? ' disabled' : '')} oncreate={helper.ontap(ctrl.reload)} />
         <button className={'fa fa-cog' + ((clock.isRunning() && !flagged) ? ' disabled' : '')} oncreate={helper.ontap(ctrl.clockSettingsCtrl.open)} />
         <button hey="home" className={'fa fa-home' + ((clock.isRunning() && !flagged) ? ' disabled' : '')} oncreate={helper.ontap(ctrl.goHome)} />
+        <span className="moveNumber">{ctrl.getMove()}</span>
       </div>
       <div className={blackClockClass} oncreate={helper.ontouch(() => onClockTouch(ctrl, 'black'))}>
         <div className="clockTapAreaContent">


### PR DESCRIPTION
I've added a counter that counts how many moves have been made , as described in the issue #2024 and added a new element to the chess clock UI.
 Portrait mode:
![portrait_screenshot](https://user-images.githubusercontent.com/83160118/176224646-1d6392d4-8bc1-4911-974c-cd795ca44649.png)

Landscape mode:
![landscape_screenshot](https://user-images.githubusercontent.com/83160118/176224703-3085296b-d5e3-4b33-8a66-2259340891fe.png)
