### PR TITLE
Allow building without firebase-messaging.

### DIFF
--- a/.github/actions/build-lichobile-apk/action.yml
+++ b/.github/actions/build-lichobile-apk/action.yml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Lichobile APK
+description: Build a Debug APK of Lichobile Android app
+
+inputs:
+  artifactName:
+    description: "The name of the output artifact for the APK."
+    required: false
+    default: "debugApk"
+  patchNonFree:
+    description: "Whether nonfree dependencies should be patched out."
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+          cache: 'npm'
+      - name: Install Dependencies
+        shell: bash
+        run: npm ci
+      - name: Patch nonfree
+        if: inputs.patchNonFree == 'true'
+        env:
+          PATCH_NONFREE_FORCE: "1"
+        shell: bash
+        run: |
+          npm run patch-nonfree
+          git diff
+      - name: Build web
+        shell: bash
+        run: npm run build
+      - name: Setup JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
+      - name: Sync android capacitor
+        shell: bash
+        run: npx cap update android
+      - name: Prepare build
+        shell: bash
+        run: npm run fetch-nnue
+      - name: Build APKs
+        working-directory: ./android
+        shell: bash
+        run: |
+          ./gradlew assembleDebug
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ inputs.artifactName }}
+          path: |
+            ./android/app/build/outputs/apk/debug/

--- a/.github/actions/build-lichobile-apk/action.yml
+++ b/.github/actions/build-lichobile-apk/action.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
 name: Lichobile APK
 description: Build a Debug APK of Lichobile Android app
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,7 @@ on:
   push:
     paths:
       - '.github/workflows/android.yml'
+      - '.github/actions/build-lichobile-apk.yml'
       - 'android/**'
     branches-ignore:
       - 'l10n_master'
@@ -14,54 +15,22 @@ jobs:
   apk:
     name: Generate debug APK
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
+      - uses: ./.github/actions/build-lichobile-apk
+
+  freeApk:
+    name: Generate free debug APK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ./.github/actions/build-lichobile-apk
         with:
-          node-version: '16'
-          cache: 'npm'
-      - name: Install Dependencies
-        run: npm ci
-      - name: Build web
-        run: npm run build
-      - name: Setup JDK
-        uses: actions/setup-java@v2
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-          cache: 'gradle'
-      - name: Sync android capacitor
-        run: npx cap update android
-      - name: Prepare build
-        working-directory: ./node_modules/capacitor-stockfish/stockfish/src
-        run: make net
-      - name: Build APKs
-        working-directory: ./android
-        run: |
-          ./gradlew assembleDebug
-      - uses: actions/upload-artifact@v2
-        with:
-          name: debugApk
-          path: |
-            ./android/app/build/outputs/apk/debug/
-      - name: Patch nonfree
-        env:
-          PATCH_NONFREE_FORCE: "1"
-        run: npm run patch-nonfree
-      - name: Sync android capacitor
-        run: npx cap update android
-      - name: Build Free APKs
-        working-directory: ./android
-        run: ./gradlew assembleDebug
+          artifactName: "debugFreeApk"
+          patchNonFree: "true"
       - name: Check non-free dependencies
         working-directory: ./android/app/build/outputs/apk/debug/
         run: |
           dexdump=$(find $ANDROID_HOME/build-tools/ -name 'dexdump' | sort -r | head -1)
           ! $dexdump app-debug.apk | grep 'Class descriptor' | grep com\/google\/firebase
           ! $dexdump app-debug.apk | grep 'Class descriptor' | grep com\/google\/android\/gms
-      - uses: actions/upload-artifact@v2
-        with:
-          name: freeDebugApk
-          path: ./android/app/build/outputs/apk/debug/

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -46,3 +46,22 @@ jobs:
           name: debugApk
           path: |
             ./android/app/build/outputs/apk/debug/
+      - name: Patch nonfree
+        env:
+          PATCH_NONFREE_FORCE: "1"
+        run: npm run patch-nonfree
+      - name: Sync android capacitor
+        run: npx cap update android
+      - name: Build Free APKs
+        working-directory: ./android
+        run: ./gradlew assembleDebug
+      - name: Check non-free dependencies
+        working-directory: ./android/app/build/outputs/apk/debug/
+        run: |
+          dexdump=$(find $ANDROID_HOME/build-tools/ -name 'dexdump' | sort -r | head -1)
+          ! $dexdump app-debug.apk | grep 'Class descriptor' | grep com\/google\/firebase
+          ! $dexdump app-debug.apk | grep 'Class descriptor' | grep com\/google\/android\/gms
+      - uses: actions/upload-artifact@v2
+        with:
+          name: freeDebugApk
+          path: ./android/app/build/outputs/apk/debug/

--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ Using android studio:
 
 More information available [here](https://capacitorjs.com/docs/android).
 
+#### Free version
+
+By default, the output APK will rely on [Firebase Cloud
+Messaging](https://firebase.google.com/docs/cloud-messaging) to support push
+notifications. However, it is possible to remove this dependency if you don't
+care about push notifications.
+
+To build the free version:
+
+    $ npm run patch-nonfree
+    $ npx cap update android
+    $ cd ./android
+    $ ./gradlew assembleDebug
+
 ### iOS
 
 You will need a `GoogleService-Info.plist` file in order to compile iOS project.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -52,11 +52,14 @@ dependencies {
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
+
+    // BEGIN NONFREE
     implementation('com.google.firebase:firebase-messaging:21.0.1') {
       exclude group: 'com.google.firebase', module: 'firebase-core'
       exclude group: 'com.google.firebase', module: 'firebase-analytics'
       exclude group: 'com.google.firebase', module: 'firebase-measurement-connector'
     }
+    // END NONFREE
 }
 
 apply from: 'capacitor.build.gradle'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,9 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.0.3'
+        // BEGIN NONFREE
         classpath 'com.google.gms:google-services:4.3.5'
+        // END NONFREE
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
         "watch": "node scripts/inject-conf && concurrently 'npm:compile-watch' 'rollup -w -c' 'npm:styles-watch'",
         "prebuild": "npm run clean && npm run compile",
         "build": "node scripts/inject-conf && concurrently 'npm:compile-date-locales' 'npm:styles' 'rollup -c' && npx cap copy",
-        "fetch-nnue": "cd node_modules/capacitor-stockfish/stockfish/src && make net && cp *.nnue ../../../../ios/App/Pods"
+        "fetch-nnue": "cd node_modules/capacitor-stockfish/stockfish/src && make net && cp *.nnue ../../../../ios/App/Pods",
+        "patch-nonfree": "node ./scripts/patch-nonfree"
     }
 }

--- a/scripts/patch-nonfree.js
+++ b/scripts/patch-nonfree.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+/**
+ * This program applies some patches to the sources in order to get rid of
+ * Firebase dependency on the Android version:
+ *
+ *   - remove dependency to @capacitor/push-notifications
+ *   - remove dependency to firebase-messaging and gms in build.gradle
+ *   - add ".free" suffix to applicationId in build.gradle
+ *   - replace push.ts with a stub implementation (push.stub.ts)
+ *
+ * As a result, push notifications will be unavailable on the app.
+ *
+ * To prevent any loss, this script will refuse to run if the current source
+ * tree has uncommitted changes. You can still force it to run by setting the
+ * PATCH_NONFREE_FORCE environment variable to "1" or "true".
+ */
+
+const childProcess = require('child_process')
+const path = require('path')
+const fs = require('fs')
+
+const rootDir = path.join(__dirname, '..')
+
+function isRepoDirty() {
+  try {
+    childProcess.execSync('git diff-index --quiet HEAD')
+  } catch (error) {
+    if (error.status === 1) {
+      return true
+    }
+    throw error
+  }
+  return false
+}
+
+function rewriteFile(filePath, func) {
+  const newContent = func(fs.readFileSync(filePath, 'utf-8'))
+  fs.writeFileSync(filePath, newContent, 'utf-8')
+}
+
+function patchPackageJson() {
+  console.log('Patching package.json.')
+  rewriteFile(
+    path.join(rootDir, 'package.json'),
+    (content) => {
+      content = content.replaceAll(/^.*"@capacitor\/push-notifications".*$[\r\n]/mg, '')
+      return content
+    }
+  )
+}
+
+function removeNonFreeSections(s) {
+  return s.replaceAll(/^.*BEGIN NONFREE[\s\S]*?END NONFREE.*$[\r\n]/mg, '')
+}
+
+function patchBuildGradle() {
+  console.log('Patching build.gradle.')
+  rewriteFile(
+    path.join(rootDir, 'android', 'build.gradle'),
+    (content) => {
+      content = removeNonFreeSections(content)
+      return content
+    }
+  )
+}
+
+
+function patchAppBuildGradle() {
+  console.log('Patching app/build.gradle.')
+  rewriteFile(
+    path.join(rootDir, 'android', 'app', 'build.gradle'),
+    (content) => {
+      content = removeNonFreeSections(content)
+      content = content.replaceAll(
+        'applicationId "org.lichess.mobileapp"',
+        'applicationId "org.lichess.mobileapp.free"',
+      )
+      return content
+    }
+  )
+}
+
+function useStubPush() {
+  console.log('Replacing push implementation with stub.')
+
+  const srcDir = path.join(rootDir, 'src')
+  const source = path.join(srcDir, 'push.stub.ts')
+  const target = path.join(srcDir, 'push.ts')
+  fs.copyFileSync(source, target)
+}
+
+if (!['true', '1'].includes(process.env['PATCH_NONFREE_FORCE']) && isRepoDirty()) {
+  console.error('Local repository has uncommitted changes. Aborting.')
+  process.exit(1)
+}
+
+patchPackageJson()
+patchBuildGradle()
+patchAppBuildGradle()
+useStubPush()

--- a/src/push.stub.ts
+++ b/src/push.stub.ts
@@ -1,0 +1,13 @@
+export default {
+  isStub: true,
+
+  init() {},
+
+  async register(): Promise<void> {
+    return Promise.resolve()
+  },
+
+  unregister(): Promise<string> {
+    return Promise.resolve('')
+  }
+}

--- a/src/push.ts
+++ b/src/push.ts
@@ -13,6 +13,8 @@ import { handleXhrError } from './utils'
 import { isForeground } from './utils/appMode'
 
 export default {
+  isStub: false,
+
   init() {
     PushNotifications.addListener('registration',
       ({ value }: Token) => {
@@ -93,4 +95,3 @@ export default {
     return fetchText('/mobile/unregister', { method: 'POST' })
   }
 }
-

--- a/src/ui/settings/settings.ts
+++ b/src/ui/settings/settings.ts
@@ -6,6 +6,7 @@ import * as helper from '../helper'
 import { dropShadowHeader, backButton } from '../shared/common'
 import layout from '../layout'
 import i18n from '../../i18n'
+import push from '../../push'
 import socket from '../../socket'
 
 interface State {
@@ -56,7 +57,7 @@ function renderBody(appVersion?: string) {
       }, i18n('pieceSet')),
       h('li.list_item.nav', {
         oncreate: helper.ontapY(() => router.set('/settings/soundNotifications'))
-      }, i18n('sound') + ' | ' + i18n('notifications'))
+      }, i18n('sound') + (push.isStub ? '' : ' | ' + i18n('notifications')))
     ]),
     appVersion ? h('section.app_version', 'v' + appVersion) : null
   ]

--- a/src/ui/settings/soundNotifications.ts
+++ b/src/ui/settings/soundNotifications.ts
@@ -11,13 +11,26 @@ import vibrate from '../../vibrate'
 
 function renderBody() {
   return h('ul.native_scroller.page.settings_list.game', [
-    h('li.list_item', h(Checkbox, {
-      label: i18n('toggleSound'),
-      name: 'sound',
-      prop: settings.general.sound,
-    })),
-    h('li.list_item', {
-    }, formWidgets.renderCheckbox(i18n('vibrateOnGameEvents'), 'vibrate', settings.general.vibrateOnGameEvents, vibrate.onSettingChange)),
+    h(
+      'li.list_item',
+      h(
+        Checkbox,
+        {
+          label: i18n('toggleSound'),
+          name: 'sound',
+          prop: settings.general.sound,
+        }
+      ),
+    ),
+    h(
+      'li.list_item',
+      {},
+      formWidgets.renderCheckbox(
+        i18n('vibrateOnGameEvents'),
+        'vibrate',
+        settings.general.vibrateOnGameEvents, vibrate.onSettingChange
+      ),
+    ),
     ...(push.isStub ? [] : [
       h(
         'li.list_item',

--- a/src/ui/settings/soundNotifications.ts
+++ b/src/ui/settings/soundNotifications.ts
@@ -18,13 +18,23 @@ function renderBody() {
     })),
     h('li.list_item', {
     }, formWidgets.renderCheckbox(i18n('vibrateOnGameEvents'), 'vibrate', settings.general.vibrateOnGameEvents, vibrate.onSettingChange)),
-    h('li.list_item', formWidgets.renderCheckbox(i18n('notifications'), 'notifications', settings.general.notifications.enable, isOn => {
-      if (isOn) {
-        push.register()
-      } else {
-        push.unregister()
-      }
-    })),
+    ...(push.isStub ? [] : [
+      h(
+        'li.list_item',
+        formWidgets.renderCheckbox(
+          i18n('notifications'),
+          'notifications',
+          settings.general.notifications.enable,
+          isOn => {
+            if (isOn) {
+              push.register()
+            } else {
+              push.unregister()
+            }
+          }
+        ),
+      ),
+    ]),
   ])
 }
 
@@ -32,7 +42,8 @@ export default {
   oncreate: helper.viewSlideIn,
 
   view() {
-    const header = dropShadowHeader(null, backButton(i18n('sound') + ' | ' + i18n('notifications')))
+    const headerTitle = i18n('sound') + (push.isStub ? '' : ' | ' + i18n('notifications'))
+    const header = dropShadowHeader(null, backButton(headerTitle))
     return layout.free(header, renderBody())
   }
 }


### PR DESCRIPTION
**Disclaimer:** This is a proposal more than anything else. I think the added maintenance burden is rather minimal, but if you think otherwise that's OK. I can as well maintain my own fork with these changes. Feel free to close. No pressure, no nothing 🙂 .

Also, as I said in [this comment](https://github.com/lichess-org/lichobile/issues/1121#issuecomment-1190883854), I think the push stub is pretty equivalent to having the "Notifications" checkbox disabled in the current Play Store version which sounds quite harmless. But I'm still not 100% sure `pushNotificationActionPerformed` hook cannot be invoked when not registered.

Also, I was able to build the debug version without issue, but the release version won't build on my machine at the moment, even on master branch with the following error:

```
> Task :app:lintVitalRelease FAILED
/home/nleroux/projects/lichobile/android/app/src/main/AndroidManifest.xml:27: Error: MainActivity must extend android.app.Activity [Instantiatable]
            android:name="org.lichess.mobileapp.MainActivity"
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/nleroux/projects/lichobile/android/app/src/main/AndroidManifest.xml:84: Error: FileProvider must extend android.content.ContentProvider [Instantiatable]
            android:name="androidx.core.content.FileProvider"
                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "Instantiatable":
   Activities, services, broadcast receivers etc. registered in the manifest
   file (or for custom views, in a layout file) must be "instantiatable" by
   the system, which means that the class must be public, it must have an
   empty public constructor, and if it's an inner class, it must be a static
   inner class.

2 errors, 0 warnings
Lint found fatal errors while assembling a release target.
```

This should probably be addressed in another PR, otherwise the F-Droid recipe might be failing.

~Also, I noticed that `libstockfish.so` was only present in the APK for the arm64 architecture (even on the Play Store release). Is that normal or is this a bug? Does stockfish work correctly on non-arm64 systems?~ After checking, it uses "stockfish-variant" (without NNUE) as a fallback. I opened https://github.com/veloce/capacitor-stockfish/pull/8 to build NNUE on other platforms.

---

This commit provides a way to build lichobile for Android without
support for push notifications, dropping the dependency on Firebase.
This is a required step towards F-Droid inclusion.

The main idea is to expose a `patch-nonfree` script that will:

- replace the push notification implementation with a stub
- remove any direct or indirect dependency to firebase (there was an
  indirect one in the @capacitor/push-notifications plugin, and a direct
  one in the app/build.gradle)
- change the applicationId so that it doesn't gets confused with the
  non-free one

The implementation is not as elegant as I'd have liked because I haven't
found a magic way to enable or disable dependencies for specific product
flavors with capacitor ([as the Android gradle plugin allows](
https://developer.android.com/studio/build/build-variants#product-flavors)).
I'm far from a capacitor expert though, so there may be better ways.

As I had to patch the JS sources anyways, I chose to not rely on
Android's product flavors at all to prevent any confusion that would
lead to build a non-free version as a free APK and vice-versa. I think
it is pretty straightforward, not too intrusive, and that it should be
manageable maintenance-wise.

The remaining changes in the JS code are needed to remove any mention of
"notifications" in the UI when using the push stub. We don't expect
notifications to work on the free version.

Fixes https://github.com/lichess-org/lichobile/issues/1121

(well, technically this doesn't "remove" the dependency to Firebase as
the main build flavor still relies on it, but I think getting rid of
that is lengthier project as lila itself depends on it)

Issues related to F-Droid inclusion:

- https://github.com/lichess-org/lichobile/issues/278
- https://github.com/lichess-org/lichobile/issues/409
- https://github.com/lichess-org/lichobile/issues/927
- https://github.com/lichess-org/lichobile/issues/1331