### PR TITLE
Add setting to disable back button during game

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -7,6 +7,7 @@ import isFunction from 'lodash-es/isFunction'
 
 import signals from './signals'
 import session from './session'
+import settings from './settings'
 import { serializeQueryParameters } from './utils'
 import redraw from './utils/redraw'
 
@@ -145,17 +146,22 @@ const backbutton: Backbutton = (() => {
       b('backbutton')
       redraw()
     } else if (!/^\/$/.test(getPath())) {
-      // if playing a game as anon ask for confirmation because there is no way
-      // back!
-      if (/^\/game\/[a-zA-Z0-9]{12}/.test(getPath()) && !session.isConnected()) {
-        Dialog.confirm({
-          title: 'Confirmation',
-          message: 'Do you really want to leave the game? You can\'t go back to it after.',
-        }).then(({ value }) => {
-          if (value) {
-            backHistory()
-          }
-        })
+      if (/^\/game\/[a-zA-Z0-9]{12}/.test(getPath())) {
+        if (settings.game.disableBackButton()) {
+          return
+        }
+        // if playing a game as anon ask for confirmation because there is
+        // no way back!
+        if (!session.isConnected()) {
+          Dialog.confirm({
+            title: 'Confirmation',
+            message: 'Do you really want to leave the game? You can\'t go back to it after.',
+          }).then(({ value }) => {
+            if (value) {
+              backHistory()
+            }
+          })
+        }
       } else {
         backHistory()
       }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -143,6 +143,7 @@ export default {
     rookCastle: prop<0 | 1>('game.rookCastle', 1),
     moveList: prop<boolean>('game.moveList', true),
     landscapeBoardSide: prop<'right' | 'left'>('game.landscapeBoardSide', 'left'),
+    disableBackButton: prop<boolean>('game.disableBackButton', false),
   },
 
   analyse: {

--- a/src/ui/settings/gameDisplay.ts
+++ b/src/ui/settings/gameDisplay.ts
@@ -59,6 +59,9 @@ function renderBody() {
       ]),
       h('li.list_item', [
         formWidgets.renderMultipleChoiceButton(i18n('blindfoldChess'), formWidgets.booleanChoice, settings.game.blindfoldChess),
+      ]),
+      h('li.list_item', [
+        formWidgets.renderMultipleChoiceButton(i18n('disableBackButton'), formWidgets.booleanChoice, settings.game.disableBackButton),
       ])
    ])
   ]

--- a/translation/source/mobile-misc.yaml
+++ b/translation/source/mobile-misc.yaml
@@ -23,3 +23,4 @@ en-GB:
   playOnline: "Play online"
   playOffline: "Play offline"
   bgThemeSyncWithSystem: "Sync with system" # Settings to synchronise background theme (dark or light) with the operating system (to support daynight automatic switch)
+  disableBackButton: "Disable back button"

--- a/www/i18n/en-GB.js
+++ b/www/i18n/en-GB.js
@@ -1331,5 +1331,6 @@ export default {
   "shareGameUrl": "Share game URL",
   "playOnline": "Play online",
   "playOffline": "Play offline",
-  "bgThemeSyncWithSystem": "Sync with system"
+  "bgThemeSyncWithSystem": "Sync with system",
+  "disableBackButton": "Disable back button"
 }


### PR DESCRIPTION
This is very useful on Android 12 without dedicated buttons, as swiping
from the edge of the screen generates a back button press event. Under
time pressure moving pieces on the edge of the board may easily cause
navigation out of the game and greatly affect the experience. I've lost
a dozen blitz games like this.

With the setting enabled, a back button press simply does nothing which
is strictly better. Even better would be to disable the swiping gestures
during game altogether, but I don't know of a way to do that.