### PR TITLE
Prevent overflow of material advantage display

### DIFF
--- a/src/styl/game.styl
+++ b/src/styl/game.styl
@@ -255,13 +255,22 @@
   @media only screen and (orientation landscape)
     fluid-type(20px, 35px)
 
+$material-piece-size = 16px
+
+.materials
+  display flex
+  max-height $material-piece-size
+  overflow hidden
+
 .material
   margin-left 6px
+  display flex
+  flex-wrap wrap
   piece
     position initial
     margin-left -6px
-    width 18px
-    height 18px
+    width $material-piece-size
+    height $material-piece-size
     background-size cover
     display inline-block
     @media only screen and (min-width 768px) and (min-height 768px)

--- a/src/ui/shared/round/view/roundView.tsx
+++ b/src/ui/shared/round/view/roundView.tsx
@@ -33,6 +33,7 @@ import { renderInlineReplay, renderReplay } from './replay'
 import OnlineRound from '../OnlineRound'
 import { countChecks, NO_CHECKS } from '../util'
 import { Position, Material } from '../'
+import times from 'lodash-es/times'
 
 export default function view(ctrl: OnlineRound) {
   const isPortrait = helper.isPortrait()
@@ -49,17 +50,21 @@ export default function view(ctrl: OnlineRound) {
 }
 
 export function renderMaterial(material: Material) {
-  const ret = Object.keys(material.pieces).map((role: string) =>
-    h('div.material', [...Array(material.pieces[role]).keys()]
-      .map(_ => h('piece', { className: role }))
-    )
+  return h.fragment(
+    {},
+    [
+      h(
+        'div.materials',
+        Object.keys(material.pieces).map((role: string) =>
+          h('div.material', times(
+            material.pieces[role],
+            _ => h('piece', { className: role })
+          ))
+        ),
+      ),
+      material.score > 0 ? h('span', `+${material.score}`) : null,
+    ]
   )
-
-  if (material.score > 0) {
-    ret.push(h('span', '+' + material.score))
-  }
-
-  return ret
 }
 
 export function viewOnlyBoardContent(fen: string, orientation: Color, lastMove?: string, variant?: VariantKey, wrapperClass?: string, customPieceTheme?: string) {


### PR DESCRIPTION
Should fix #2178.

# Before

When a player's material advantage takes more than the available screen space to display, it currently wraps, which displaces the board:

<img width="288" alt="Screen Shot 2022-09-06 at 7 16 19 PM" src="https://user-images.githubusercontent.com/569991/188756346-717ab7e0-691d-46f9-ba4e-6e7e892323bf.png">


# After

Material advantage row is height-restricted to exactly one piece. Advantage number is never hidden, but individual piece representations are hidden when necessary.

<img width="308" alt="Screen Shot 2022-09-06 at 7 13 12 PM" src="https://user-images.githubusercontent.com/569991/188756249-e8ca8b7e-c176-4b6b-8a4b-e2596bba88fd.png">

Does not affect screens of sufficient width.

<img width="477" alt="Screen Shot 2022-09-06 at 7 13 06 PM" src="https://user-images.githubusercontent.com/569991/188756248-f8db5b9f-9043-4f44-80b8-bb482f3dc7ef.png">