### PR TITLE
remove deprecated ionic maven repository

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -37,9 +37,6 @@ android {
 
 
 repositories {
-    maven {
-        url  "https://dl.bintray.com/ionic-team/capacitor"
-    }
     flatDir{
         dirs '../capacitor-cordova-android-plugins/src/main/libs', 'libs'
     }


### PR DESCRIPTION
It was deprecated a while ago because of JCenter shutdown. And F-Droid scanner complains about it.

See:

- https://github.com/ionic-team/capacitor/discussions/4542#discussioncomment-707978
- https://github.com/lichess-org/lichobile/issues/1121#issuecomment-1239735238