### PR TITLE
remove Sentry from external services

### DIFF
--- a/COPYING.md
+++ b/COPYING.md
@@ -70,4 +70,3 @@ External services
 Lichobile relies on these external services:
 
 * [lichess.org](https://lichess.org)
-* [Sentry](https://sentry.io)


### PR DESCRIPTION
Correct me if I'm wrong, but it seems that this project is no longer sending data to Sentry, despite what's claimed in the COPYING file. So this PR just removes the mention to Sentry.

Probably removed somewhere around here : e2274bb85c4b9062856603e73318f83394754f71 fc31285342b4d56fd86d3445cf4c576ad84a803f

See also: https://gitlab.com/fdroid/fdroiddata/-/merge_requests/11707/diffs#note_1095861444