### PR TITLE
Add fallback values for promo menu

### DIFF
--- a/src/styl/game.styl
+++ b/src/styl/game.styl
@@ -302,9 +302,11 @@ $material-piece-size = 16px
   column-gap 5px
   piece
     position relative
+    width 60px // fallback
     width calc(min(12.5%, var(--overlay-height)))
     // CSS hack: padding-bottom is calculated based on width of parent, so we can get a square div here
-    height 0
+    height 60px // fallback
+    height calc(min(0px, 60px))
     padding-bottom calc(min(12.5%, var(--overlay-height)))
 
 .tableHeader


### PR DESCRIPTION
Old Android WebView versions might not support [calc](https://caniuse.com/calc) or [math](https://caniuse.com/css-math-functions) functions properly, if at all, which makes the promo menu appear empty.

To solve this, either the user needs to update their WebView to the latest version or we can add fallback values as a catchall.

These are the tests I've done on my Android 8.1 device :

* WebView 70 + 1.7.16 release -> Empty Menu
* WebView 70 + 1.7.16 release (with fallbacks) -> Correct Menu
* WebView 104 + 1.7.16 release -> Correct Menu

I don't know if this fully fixes the empty menu issue, but for my device it appears to be the case.