### PR TITLE
Fix #2192: Shuffle icon for Puzzle Resync

### DIFF
--- a/src/ui/training/trainingView.ts
+++ b/src/ui/training/trainingView.ts
@@ -66,7 +66,7 @@ function renderActionsBar(ctrl: TrainingCtrl) {
       oncreate: helper.ontap(ctrl.goToAnalysis, () => Toast.show({ text: i18n('analysis'), duration: 'short', position: 'bottom' })),
       disabled: ctrl.vm.mode !== 'view'
     }),
-    session.isConnected() ? h('button.action_bar_button.training_action.fa.fa-refresh', {
+    session.isConnected() ? h('button.action_bar_button.training_action.fa.fa-random', {
       oncreate: helper.ontap(ctrl.resync, () => Toast.show({ text: 'Sync and refresh saved puzzles', duration: 'short', position: 'bottom' }))
     }) : null,
     h('button.action_bar_button.training_action.fa.fa-backward', {


### PR DESCRIPTION
Fixes https://github.com/lichess-org/lichobile/issues/2192

Retry and Resync use the same Icon, causing confusion. In this PR, the icon for Resync is replaced with [Shuffle / Random](https://fontawesome.com/v4/icon/random)


![Screenshot of Lichess Mobile app with Shuffle icon for resync](https://user-images.githubusercontent.com/16903044/190392091-2e97812f-c574-4c7d-a29c-41fa677b418f.png)
