### PR TITLE
Add password manager support

### DIFF
--- a/src/ui/loginModal.ts
+++ b/src/ui/loginModal.ts
@@ -35,14 +35,16 @@ export default {
         h('form.defaultForm.login', {
           onsubmit: onLogin
         }, [
-          formError && !isTotpError(formError) ?  h('div.form-error', formError) : null,
+          formError && !isTotpError(formError) ? h('div.form-error', formError) : null,
           formError === 'InvalidTotpToken' ? h('div.form-error', i18n('invalidAuthenticationCode')) : null,
           h('div.field', [
             h('input#username', {
               type: isTotpError(formError) ? 'hidden' : 'text',
               className: formError ? 'form-error' : '',
+              name: 'username',
+              'aria-label': 'Username',
               placeholder: i18n('username'),
-              autocomplete: 'off',
+              autocomplete: 'username',
               autocapitalize: 'off',
               autocorrect: 'off',
               spellcheck: false,
@@ -53,7 +55,10 @@ export default {
             h('input#password', {
               type: isTotpError(formError) ? 'hidden' : 'password',
               className: formError ? 'form-error' : '',
+              name: 'password',
+              'aria-label': 'Password',
               placeholder: i18n('password'),
+              autocomplete: 'current-password',
               required: true
             }),
           ]),
@@ -72,8 +77,10 @@ export default {
             ]),
           ] : null,
           h('div.submit', [
-            h('button.defaultButton', {
-              disabled: loading
+            h('button.defaultButton[type=submit]', {
+              disabled: loading,
+              value: 'LOGIN',
+              'aria-label': 'Sign In',
             }, i18n('signIn'))
           ])
         ]),

--- a/src/ui/signupModal.ts
+++ b/src/ui/signupModal.ts
@@ -78,25 +78,30 @@ function renderForm() {
       h('div.field', [
         formError && formError.username ?
           h('div.form-error', formError.username[0]) : null,
-        h('input#pseudo[type=text]', {
+        h('input#username[type=text]', {
           className: formError && formError.username ? 'form-error' : '',
+          onfocus: scrollToTop,
+          oninput: debounce(oninput, 500),
+          name: 'username',
+          'aria-label': 'Username',
           placeholder: i18n('username'),
-          autocomplete: 'off',
+          autocomplete: 'username',
           autocapitalize: 'off',
           autocorrect: 'off',
           spellcheck: false,
-          required: true,
-          onfocus: scrollToTop,
-          oninput: debounce(oninput, 500),
+          required: true
         }),
       ]),
       h('div.field', [
         formError && formError.email ?
           h('div.form-error', formError.email[0]) : null,
         h('input#email[type=email]', {
-          onfocus: scrollToTop,
           className: formError && formError.email ? 'form-error' : '',
+          onfocus: scrollToTop,
+          name: 'email',
+          'aria-label': 'Email',
           placeholder: i18n('email'),
+          autocomplete: 'email',
           autocapitalize: 'off',
           autocorrect: 'off',
           spellcheck: false,
@@ -107,15 +112,21 @@ function renderForm() {
         formError && formError.password ?
           h('div.form-error', formError.password[0]) : null,
         h('input#password[type=password]', {
-          onfocus: scrollToTop,
           className: formError && formError.password ? 'form-error' : '',
+          onfocus: scrollToTop,
+          name: 'password',
+          'aria-label': 'Password',
           placeholder: i18n('password'),
-          required: true
+          autocomplete: 'new-password',
+          required: true,
+          passwordrules: 'minlength: 20; required: lower; required: upper; required: digit; required: [-];'
         })
       ]),
       h('div.submit', [
-        h('button.defaultButton', {
-          disabled: loading
+        h('button.defaultButton[type=submit]', {
+          disabled: loading,
+          value: 'SIGNUP',
+          'aria-label': 'Sign Up',
         }, i18n('signUp'))
       ])
     ])


### PR DESCRIPTION
Elements in the Signup and Login pages don't have sufficient labels and attributes for password managers to identify them and offer to auto-fill. This PR should enable most password manages to identify them and also slightly improve accessibility.

The `passwordrules` field is to help password generators, and will not get in the way of users using whichever password they choose to.

Made with the help of:
- https://developer.apple.com/password-rules/
- https://hidde.blog/making-password-managers-play-ball-with-your-login-form/
- https://developer.1password.com/docs/web/compatible-website-design/
- https://support.lastpass.com/help/how-do-i-configure-my-website-to-work-with-lastpass

The `autocomplete` field values are updated to match that of lichess.com, which also happen to be best practices and are useful for password managers.