### PR TITLE
Tournament wikiPath has been replaced with url

### DIFF
--- a/src/lichess/interfaces/game.ts
+++ b/src/lichess/interfaces/game.ts
@@ -235,5 +235,5 @@ export interface Opening {
   readonly eco: string
   readonly name: string
   readonly fen?: string
-  readonly wikiPath?: string
+  readonly url?: string
 }

--- a/src/ui/tournament/detail/tournamentView.tsx
+++ b/src/ui/tournament/detail/tournamentView.tsx
@@ -125,9 +125,9 @@ function tournamentCreatorInfo(data: Tournament, startsAt: string) {
 
 function tournamentPositionInfo(position: Opening) {
   return (
-    <div className={'tournamentPositionInfo' + (position.wikiPath ? ' withLink' : '')}
-      oncreate={helper.ontapY(() => position && position.wikiPath &&
-        window.open(`https://en.wikipedia.org/wiki/${position.wikiPath}`, '_blank')
+    <div className={'tournamentPositionInfo' + (position.url ? ' withLink' : '')}
+      oncreate={helper.ontapY(() => position && position.url &&
+        window.open(position.url, '_blank')
       )}
     >
       {position.eco + ' ' + position.name}

--- a/www/data/positions.json
+++ b/www/data/positions.json
@@ -516,7 +516,7 @@
         "eco": "E43",
         "fen": "rnbqk2r/p1pp1ppp/1p2pn2/8/1bPP4/2N1P3/PP3PPP/R1BQKBNR w KQkq - 0 5",
         "name": "Nimzo-Indian Defence: Fischer Variation",
-        "wikiPath": "Nimzo-Indian_Defence#4...b6"
+        "url": "https://lichess.org/opening/Nimzo-Indian_Defense_St_Petersburg_Variation/d4_Nf6_c4_e6_Nc3_Bb4_e3_b6"
       },
       {
         "eco": "E41",


### PR DESCRIPTION
In https://github.com/lichess-org/lila/commit/4069e5cda6d58f4a7bdb6c68e93529b58592beda#diff-af31ce017b5b4a92ea00b1a33043e014c674e621a5709d4ff425e54c5b6383dfL587

It now contains a link to the https://lichess.org/opening entry.