### PR TITLE
Update README.md (Added link to App Store)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,16 @@ It talks to a native [Stockfish](https://stockfishchess.org/) engine, [supportin
 Multi-variant chess library is brought by [a JavaScript version of scalachess](https://github.com/veloce/scalachessjs).
 
 ## Download
+<table>
+  <tr>
+<td valign="top"><a href="https://f-droid.org/packages/org.lichess.mobileapp.free/"><img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png" alt="Get it on F-Droid" style="height: 80px"></a></td>
 
-[<img src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png"
-     alt="Get it on F-Droid"
-     height="80">](https://f-droid.org/packages/org.lichess.mobileapp.free/)
-[<img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png"
-     alt="Get it on Google Play"
-     height="80">](https://play.google.com/store/apps/details?id=org.lichess.mobileapp)
 
+<td valign="top"><a href="https://play.google.com/store/apps/details?id=org.lichess.mobileapp"><img src="https://play.google.com/intl/en_us/badges/images/generic/en-play-badge.png" alt="Get it on Google Play" style="height: 80px"></a></td>
+
+<td "><a href="https://apps.apple.com/us/app/lichess-online-chess/id968371784?itsct=apps_box_badge&amp;itscg=30200"><img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1425427200" alt="Download on the App Store" style="height: 52px; padding: 14px;"></a></td>
+  </tr>
+</table>
 or get the APK from the [Releases section](https://github.com/lichess-org/lichobile/releases/latest)
 
 ## Required dependencies


### PR DESCRIPTION
🔺I noticed there is no link to the app store in the documentation. I thought it would be a good idea to add it.
🔺**The badge is taken from the official apple site.**
🔺It is important to note that the **App Store badge is not indented**, unlike Google and F-droid. Therefore, I had to add a table so that the difference could not be seen.
![img1](https://user-images.githubusercontent.com/101352977/236025539-3aec0875-deb3-464c-9bb9-a03cf8533c0f.png)
![img2](https://user-images.githubusercontent.com/101352977/236025579-c724c675-ecad-47d1-9010-929cdd28d740.png)

* Added App Store link;
* Removed markdown, added html(via a table);

_Thanks for reviewing it._