### PR TITLE
Fix sorting and filtering studies

### DIFF
--- a/src/ui/study/StudyIndexCtrl.ts
+++ b/src/ui/study/StudyIndexCtrl.ts
@@ -1,12 +1,14 @@
+import * as xhr from './studyXhr'
+
+import { PagerCategory, PagerData, PagerOrder } from '../../lichess/interfaces/study'
+
+import { Paginator } from '../../lichess/interfaces'
+import { batchRequestAnimationFrame } from '../../utils/batchRAF'
 import debounce from 'lodash-es/debounce'
 import { fromNow } from '../../i18n'
 import { handleXhrError } from '../../utils'
-import { batchRequestAnimationFrame } from '../../utils/batchRAF'
 import redraw from '../../utils/redraw'
 import router from '../../router'
-import { Paginator } from '../../lichess/interfaces'
-import { PagerData, PagerCategory, PagerOrder } from '../../lichess/interfaces/study'
-import * as xhr from './studyXhr'
 
 export interface PagerDataWithDate extends PagerData {
   date: string
@@ -96,12 +98,12 @@ export default class StudyIndexCtrl {
 
   public readonly onCatChange = (e: Event): void => {
     const cat = (e.target as HTMLSelectElement).value
-    router.setQueryParams({ cat }, true)
+    router.setQueryParams({cat: cat, order: this.order  }, true)
   }
 
   public readonly onOrderChange = (e: Event): void => {
     const order = (e.target as HTMLSelectElement).value
-    router.setQueryParams({ order }, true)
+    router.setQueryParams({ cat: this.cat, order: order  }, true)
   }
 
   public readonly onScroll = (e: Event): void => {


### PR DESCRIPTION
Previously, whenever you would use one of the filter or sort controls on the study page, it would reset the other one. That meant that it was impossible to view your own studies sorted by recently updated for example. This change preserves the filter when you change the sort and vice versa. Here's a video showing that the change works: 


https://github.com/lichess-org/lichobile/assets/504401/850eb6e4-23d7-4a57-8efb-64884981f268

