### PR TITLE
Cache featured streamer results for 15 seconds

### DIFF
--- a/src/ui/home/homeXhr.ts
+++ b/src/ui/home/homeXhr.ts
@@ -1,4 +1,4 @@
-import { fetchJSON } from '../../http'
+import { fetchCachedJSON, fetchJSON } from '../../http'
 import { Streamer } from '../../lichess/interfaces'
 import { PuzzleData } from '../../lichess/interfaces/training'
 import { TournamentListItem } from '../../lichess/interfaces/tournament'
@@ -8,7 +8,11 @@ interface FeaturedTournamentData {
 }
 
 export function featuredStreamers(): Promise<readonly Streamer[]> {
-  return fetchJSON('/api/streamer/featured', undefined)
+  return fetchCachedJSON(
+    'streamer/featured',
+    15,
+    '/api/streamer/featured',
+  )
 }
 
 export function dailyPuzzle(): Promise<PuzzleData> {


### PR DESCRIPTION
Might close #2319. It's hard to say if this will fix it without the root cause; I was unable to repro the issue on the development web browser. Notably, this uses a variable in memory, not local storage, so if the issue is app relaunch or something (seems unlikely multiple times a second but you never know), this won't solve the problem.