### PR TITLE
Android monochrome icons for ic_launcher.xml

### DIFF
--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/ic_launcher_background"/>
     <foreground android:drawable="@mipmap/ic_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
 </adaptive-icon>


### PR DESCRIPTION
Currently android monochrome icons only works on devices that use the ic_launcher_round.xml (mostly older pixels), this one line patch add support for more devices that use the ic_launcher.xml as the source of the icon.