### PR TITLE
Password fix

### DIFF
--- a/src/lichess/tournament.ts
+++ b/src/lichess/tournament.ts
@@ -5,5 +5,5 @@ export function isIn(data: Tournament): boolean {
 }
 
 export function previouslyJoined(data: Tournament): boolean {
-  return data.me != null
+  return !!data.me
 }

--- a/src/ui/tournament/detail/joinForm.tsx
+++ b/src/ui/tournament/detail/joinForm.tsx
@@ -5,6 +5,7 @@ import router from '../../../router'
 import TournamentCtrl from './TournamentCtrl'
 import formWidgets from '../../shared/form'
 import settings from '../../../settings'
+import * as helper from '../../helper'
 
 let isOpen = false
 let tournamentCtrl: TournamentCtrl
@@ -52,7 +53,7 @@ function renderForm() {
         <div className={'select_input no_arrow_after' + (t.private ? '' : ' notVisible')}>
           <div className="text_input_container">
             <label>Password: </label>
-            <input type="text" id="tournamentPassword" className="passwordField" />
+            <input type="text" id="tournamentPassword" className="passwordField" autocapitalize="off" autocomplete="off" oncreate={helper.autofocus} />
           </div>
         </div>
         <div className={'select_input no_arrow_after' + (t.teamBattle ? '' : ' notVisible')}>

--- a/src/ui/tournament/detail/tournamentView.tsx
+++ b/src/ui/tournament/detail/tournamentView.tsx
@@ -75,7 +75,7 @@ export function renderFooter(ctrl: TournamentCtrl): Mithril.Child {
           }
         </button> : h.fragment({key: 'noChat'}, [])
       }
-      { ctrl.hasJoined ? withdrawButton(ctrl, t) : joinButton(ctrl, t) }
+      { ctrl.hasJoined ? withdrawButton(ctrl) : joinButton(ctrl) }
     </div>
   )
 }
@@ -181,7 +181,8 @@ function tournamentSpotlightInfo(spotlight: Spotlight) {
   )
 }
 
-function joinButton(ctrl: TournamentCtrl, t: Tournament) {
+function joinButton(ctrl: TournamentCtrl) {
+  const t = ctrl.tournament
   if (!session.isConnected() ||
     t.isFinished ||
     settings.game.supportedVariants.indexOf(t.variant) < 0 ||
@@ -189,9 +190,9 @@ function joinButton(ctrl: TournamentCtrl, t: Tournament) {
     (t.teamBattle && t.teamBattle.joinWith.length === 0)) {
     return h.fragment({key: 'noJoinButton'}, [])
   }
-  const action = ((t.private || t.teamBattle) && !previouslyJoined(t)) ?
-    () => joinForm.open(ctrl) :
-    () => ctrl.join()
+  const action = () => ((ctrl.tournament.private || ctrl.tournament.teamBattle) && !previouslyJoined(ctrl.tournament)) ?
+    joinForm.open(ctrl) :
+    ctrl.join()
 
   return (
     <button key="joinButton" className="action_bar_button fa fa-play" oncreate={helper.ontap(
@@ -202,7 +203,8 @@ function joinButton(ctrl: TournamentCtrl, t: Tournament) {
   )
 }
 
-function withdrawButton(ctrl: TournamentCtrl, t: Tournament) {
+function withdrawButton(ctrl: TournamentCtrl) {
+  const t = ctrl.tournament
   if (t.isFinished || settings.game.supportedVariants.indexOf(t.variant) < 0) {
     return h.fragment({key: 'noWithdrawButton'}, [])
   }


### PR DESCRIPTION
withdrawing from an unstarted private tournament removes the user, which requires entering the password again when rejoining, but the app doesn't prompt for the password again