### PR TITLE
Fix for https://github.com/lichess-org/lichobile/issues/2400

### DIFF
--- a/www/i18n/en-GB.js
+++ b/www/i18n/en-GB.js
@@ -1062,6 +1062,7 @@ export default {
   "maxTimePlaying": "Max time spent playing",
   "now": "now",
   "preferences": "Preferences",
+  "gameDisplay": "Game display",
   "display": "Display",
   "pieceAnimation": "Piece animation",
   "materialDifference": "Material difference",


### PR DESCRIPTION
Added missing entry for "Game Display"
Probably the next entry "display" was intended to be this one and was incorrect due to a typo; in this case it could be removed