### PR TITLE
Correct imported tag in GameFilter

### DIFF
--- a/src/lichess/interfaces/user.ts
+++ b/src/lichess/interfaces/user.ts
@@ -1,7 +1,7 @@
 import { Profile } from '~/session'
 import { GameSource, GameStatus, ClockData, Opening } from './game'
 
-export type GameFilter = 'all' | 'rated' | 'win' | 'loss' | 'draw' | 'bookmark' | 'me' | 'import' | 'playing'
+export type GameFilter = 'all' | 'rated' | 'win' | 'loss' | 'draw' | 'bookmark' | 'me' | 'imported' | 'playing'
 
 export interface UserGamesCount {
   readonly all: number


### PR DESCRIPTION
Hi!

As reported here https://github.com/lichess-org/lichobile/issues/2375 and https://github.com/lichess-org/lichobile/issues/2331 filtering for imported games is not working, which this PR attempts to fix. 

Although it cannot be found in the API doc (https://lichess.org/api#tag/Games/operation/apiGamesUser), judging by the request WEB makes it must be `imported` instead of `import`
